### PR TITLE
Tex2 70 cb

### DIFF
--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -331,7 +331,9 @@ class AppBase {
 	virtual void		setFullScreen( bool fullScreen, const FullScreenOptions &options = FullScreenOptions() ) { getWindow()->setFullScreen( fullScreen, options ); }
 
 	//! Returns the number of seconds which have elapsed since application launch
-	double				getElapsedSeconds() const { return mTimer.getSeconds(); }
+	//double				getElapsedSeconds() const { return mTimer.getSeconds(); }
+// CB
+double				getElapsedSeconds() const { return mFrameCount / 60.0; }
 	//! Returns the number of animation frames which have elapsed since application launch
 	uint32_t			getElapsedFrames() const { return mFrameCount; }
 

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -514,6 +514,8 @@ inline Area		getWindowBounds() { return AppBase::get()->getWindowBounds(); }
 inline float	getWindowContentScale() { return AppBase::get()->getWindowContentScale(); }
 //! Returns the maximum frame-rate the active App will attempt to maintain.
 inline float	getFrameRate() { return AppBase::get()->getFrameRate(); }
+//! Returns the current frame rate setting - either real-time or capture mode
+inline float	getPlaybackFrameRate() { return AppBase::get()->getPlaybackFrameRate(); }
 //! Sets the maximum frame-rate the active App will attempt to maintain.
 inline void		setFrameRate( float frameRate ) { AppBase::get()->setFrameRate( frameRate ); }
 //! Returns whether the active App is in full-screen mode or not.

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -334,7 +334,7 @@ class AppBase {
 	//double				getElapsedSeconds() const { return mTimer.getSeconds(); }
 	double				getTrueElapsedSeconds() const { return mTimer.getSeconds(); }
 	double				getElapsedSeconds() const {
-		return mDoPlaybackForCapture ? mFrameCount / getFrameRate() : mTimer.getSeconds();
+		return mDoPlaybackForCapture ? mFrameCount / mCaptureFrameRate : mTimer.getSeconds();
 	}
 	//! Returns the number of animation frames which have elapsed since application launch
 	uint32_t			getElapsedFrames() const { return mFrameCount; }
@@ -344,6 +344,8 @@ class AppBase {
 		mFpsLastSampleTime = getElapsedSeconds();
 		mFpsLastSampleFrame = mFrameCount;
 	}
+	float getCaptureFrameRate() const { return mCaptureFrameRate; }
+	void  setCaptureFrameRate( float frameRate ) { mCaptureFrameRate = frameRate; }
 
 	//! Returns whether the app is registered to receive multiTouch events from the operating system, configurable via Settings at startup. Disabled by default on desktop platforms, enabled on mobile.
 	bool				isMultiTouchEnabled() const				{ return mMultiTouchEnabled; }
@@ -450,6 +452,7 @@ class AppBase {
 	RendererRef				mDefaultRenderer;
 	
 	bool					mDoPlaybackForCapture;
+	float					mCaptureFrameRate;
 
 	std::vector<std::string>	mCommandLineArgs;
 	std::shared_ptr<Timeline>	mTimeline;

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -332,6 +332,7 @@ class AppBase {
 
 	//! Returns the number of seconds which have elapsed since application launch
 	//double				getElapsedSeconds() const { return mTimer.getSeconds(); }
+	double				getTrueElapsedSeconds() const { return mTimer.getSeconds(); }
 	double				getElapsedSeconds() const {
 		return mDoPlaybackForCapture ? mFrameCount / getFrameRate() : mTimer.getSeconds();
 	}

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -333,7 +333,8 @@ class AppBase {
 	//! Returns the number of seconds which have elapsed since application launch
 	//double				getElapsedSeconds() const { return mTimer.getSeconds(); }
 // CB
-double				getElapsedSeconds() const { return mFrameCount / 60.0; }
+//double				getElapsedSeconds() const { return mFrameCount / 60.0; }
+double				getElapsedSeconds() const { return mFrameCount / getFrameRate(); }
 	//! Returns the number of animation frames which have elapsed since application launch
 	uint32_t			getElapsedFrames() const { return mFrameCount; }
 

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -332,11 +332,17 @@ class AppBase {
 
 	//! Returns the number of seconds which have elapsed since application launch
 	//double				getElapsedSeconds() const { return mTimer.getSeconds(); }
-// CB
-//double				getElapsedSeconds() const { return mFrameCount / 60.0; }
-double				getElapsedSeconds() const { return mFrameCount / getFrameRate(); }
+	double				getElapsedSeconds() const {
+		return mDoPlaybackForCapture ? mFrameCount / getFrameRate() : mTimer.getSeconds();
+	}
 	//! Returns the number of animation frames which have elapsed since application launch
 	uint32_t			getElapsedFrames() const { return mFrameCount; }
+	
+	void setPlaybackForCapture ( bool doPlaybackForCapture )  {
+		mDoPlaybackForCapture = doPlaybackForCapture;
+		mFpsLastSampleTime = getElapsedSeconds();
+		mFpsLastSampleFrame = mFrameCount;
+	}
 
 	//! Returns whether the app is registered to receive multiTouch events from the operating system, configurable via Settings at startup. Disabled by default on desktop platforms, enabled on mobile.
 	bool				isMultiTouchEnabled() const				{ return mMultiTouchEnabled; }
@@ -441,6 +447,8 @@ double				getElapsedSeconds() const { return mFrameCount / getFrameRate(); }
 	double					mFpsSampleInterval;
 	bool					mMultiTouchEnabled, mHighDensityDisplayEnabled;
 	RendererRef				mDefaultRenderer;
+	
+	bool					mDoPlaybackForCapture;
 
 	std::vector<std::string>	mCommandLineArgs;
 	std::shared_ptr<Timeline>	mTimeline;

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -346,6 +346,10 @@ class AppBase {
 	}
 	float getCaptureFrameRate() const { return mCaptureFrameRate; }
 	void  setCaptureFrameRate( float frameRate ) { mCaptureFrameRate = frameRate; }
+	
+	float getPlaybackFrameRate() const {
+		return mDoPlaybackForCapture ? mCaptureFrameRate : getFrameRate();
+	}
 
 	//! Returns whether the app is registered to receive multiTouch events from the operating system, configurable via Settings at startup. Disabled by default on desktop platforms, enabled on mobile.
 	bool				isMultiTouchEnabled() const				{ return mMultiTouchEnabled; }

--- a/include/cinder/qtime/QuickTimeImplAvf.h
+++ b/include/cinder/qtime/QuickTimeImplAvf.h
@@ -127,9 +127,9 @@ class MovieBase {
 	//! Sets whether the movie is set to loop during playback. If \a palindrome is true, the movie will "ping-pong" back and forth
 	void		setLoop( bool loop = true, bool palindrome = false );
 	//! Advances the movie by one frame (a single video sample). Ignores looping settings.
-	bool		stepForward();
+	bool		stepForward( int frms = 1 );
 	//! Steps backward by one frame (a single video sample). Ignores looping settings.
-	bool		stepBackward();
+	bool		stepBackward( int frms = 1 );
 	/** Sets the playback rate, which begins playback immediately for nonzero values.
 	 * 1.0 represents normal speed. Negative values indicate reverse playback and \c 0 stops.
 	 *

--- a/src/cinder/TimelineItem.cpp
+++ b/src/cinder/TimelineItem.cpp
@@ -117,7 +117,7 @@ void TimelineItem::stepTo( float newTime, bool reverse )
 	}
 	// CB - I've fixed this bug before
 	//else if( ( ! mLoop ) && ( ! mInfinite ) ) { // newTime >= endTime
-	else if( ( ! mLoop ) && ( ! mInfinite ) && !mPingPong ) { // newTime >= endTime
+	else if( ( ! mLoop ) && ( ! mInfinite ) && ( ! mPingPong ) ) { // newTime >= endTime
 		if( ( ! mComplete ) && ( ! reverse ) ) {
 			mComplete = true;
 			mReverseComplete = false;

--- a/src/cinder/TimelineItem.cpp
+++ b/src/cinder/TimelineItem.cpp
@@ -115,7 +115,9 @@ void TimelineItem::stepTo( float newTime, bool reverse )
 			complete( true );
 		}
 	}
-	else if( ( ! mLoop ) && ( ! mInfinite ) ) { // newTime >= endTime
+	// CB - I've fixed this bug before
+	//else if( ( ! mLoop ) && ( ! mInfinite ) ) { // newTime >= endTime
+	else if( ( ! mLoop ) && ( ! mInfinite ) && !mPingPong ) { // newTime >= endTime
 		if( ( ! mComplete ) && ( ! reverse ) ) {
 			mComplete = true;
 			mReverseComplete = false;

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -92,7 +92,7 @@ void AppBase::Settings::setShouldQuit( bool shouldQuit )
 
 AppBase::AppBase()
 	: mFrameCount( 0 ), mAverageFps( 0 ), mFpsSampleInterval( 1 ), mTimer( true ), mTimeline( Timeline::create() ),
-		mFpsLastSampleFrame( 0 ), mFpsLastSampleTime( 0 )
+		mFpsLastSampleFrame( 0 ), mFpsLastSampleTime( 0 ), mDoPlaybackForCapture( false )
 {
 	sInstance = this;
 
@@ -171,28 +171,22 @@ void AppBase::privateUpdate__()
 
 	mSignalUpdate.emit();
 
-//CI_LOG_I("update()");
+	//CI_LOG_I("update()");
 	update();	// call <ourApp>::update()
 	
-// CB
-// mTimer is used only here and in getElapsedSeconds()
-// mFrameRate defaults to 60.0f, used in startAnimationTimer() to create a timer which fires at the frame rate
-//double now = mTimer.getSeconds();
-//double now = mFrameCount / 60.0;
-double now = mFrameCount / getFrameRate();
+	// mTimer is used only here and in getElapsedSeconds()
+	// mFrameRate defaults to 60.0f, used in startAnimationTimer() to create a timer which fires at the frame rate
+	double now = getElapsedSeconds();
 
 	// update master timeline - not sure why this is done after update()
-	//mTimeline->stepTo( static_cast<float>( getElapsedSeconds() ) );
 	mTimeline->stepTo( static_cast<float>( now ) );
 
 	// update FPS statistics
 	// mFpsSampleInterval == 1 by default
-	//double now = mTimer.getSeconds();
 	if( now > mFpsLastSampleTime + mFpsSampleInterval ) {
 		//calculate average Fps over sample interval
 		uint32_t framesPassed = mFrameCount - mFpsLastSampleFrame;
 		mAverageFps = (float)(framesPassed / (now - mFpsLastSampleTime));
-
 		mFpsLastSampleTime = now;
 		mFpsLastSampleFrame = mFrameCount;
 	}

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -92,7 +92,8 @@ void AppBase::Settings::setShouldQuit( bool shouldQuit )
 
 AppBase::AppBase()
 	: mFrameCount( 0 ), mAverageFps( 0 ), mFpsSampleInterval( 1 ), mTimer( true ), mTimeline( Timeline::create() ),
-		mFpsLastSampleFrame( 0 ), mFpsLastSampleTime( 0 ), mDoPlaybackForCapture( false )
+		mFpsLastSampleFrame( 0 ), mFpsLastSampleTime( 0 ),
+		mDoPlaybackForCapture( false ), mCaptureFrameRate( 30 )
 {
 	sInstance = this;
 
@@ -155,7 +156,7 @@ void AppBase::privateSetup__()
 	setup();
 }
 
-// CB - this is the central update() call in the application
+// this is the central update() call in the application
 void AppBase::privateUpdate__()
 {
 	mFrameCount++;
@@ -171,18 +172,18 @@ void AppBase::privateUpdate__()
 
 	mSignalUpdate.emit();
 
-	//CI_LOG_I("update()");
 	update();	// call <ourApp>::update()
 	
 	// mTimer is used only here and in getElapsedSeconds()
 	// mFrameRate defaults to 60.0f, used in startAnimationTimer() to create a timer which fires at the frame rate
+	// mCaptureFrameRate defaults to 30.0f since that's what works best for quicktime videos
 	double now = getElapsedSeconds();
 
 	// update master timeline - not sure why this is done after update()
 	mTimeline->stepTo( static_cast<float>( now ) );
 
 	// update FPS statistics
-	// mFpsSampleInterval == 1 by default
+	// mFpsSampleInterval == 1.0 secs by default
 	if( now > mFpsLastSampleTime + mFpsSampleInterval ) {
 		//calculate average Fps over sample interval
 		uint32_t framesPassed = mFrameCount - mFpsLastSampleFrame;

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -155,6 +155,7 @@ void AppBase::privateSetup__()
 	setup();
 }
 
+// CB - this is the central update() call in the application
 void AppBase::privateUpdate__()
 {
 	mFrameCount++;
@@ -170,10 +171,12 @@ void AppBase::privateUpdate__()
 
 	mSignalUpdate.emit();
 
-	update();
+	update();	// call <ourApp>::update()
 
+	// update master timeline - not sure why this is done after update()
 	mTimeline->stepTo( static_cast<float>( getElapsedSeconds() ) );
 
+	// update FPS statistics
 	double now = mTimer.getSeconds();
 	if( now > mFpsLastSampleTime + mFpsSampleInterval ) {
 		//calculate average Fps over sample interval

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -173,12 +173,19 @@ void AppBase::privateUpdate__()
 
 //CI_LOG_I("update()");
 	update();	// call <ourApp>::update()
+	
+// CB
+// mTimer is used only here and in getElapsedSeconds()
+//double now = mTimer.getSeconds();
+double now = mFrameCount / 60.0;
 
 	// update master timeline - not sure why this is done after update()
-	mTimeline->stepTo( static_cast<float>( getElapsedSeconds() ) );
+	//mTimeline->stepTo( static_cast<float>( getElapsedSeconds() ) );
+	mTimeline->stepTo( static_cast<float>( now ) );
 
 	// update FPS statistics
-	double now = mTimer.getSeconds();
+	// mFpsSampleInterval == 1 by default
+	//double now = mTimer.getSeconds();
 	if( now > mFpsLastSampleTime + mFpsSampleInterval ) {
 		//calculate average Fps over sample interval
 		uint32_t framesPassed = mFrameCount - mFpsLastSampleFrame;

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -176,8 +176,10 @@ void AppBase::privateUpdate__()
 	
 // CB
 // mTimer is used only here and in getElapsedSeconds()
+// mFrameRate defaults to 60.0f, used in startAnimationTimer() to create a timer which fires at the frame rate
 //double now = mTimer.getSeconds();
-double now = mFrameCount / 60.0;
+//double now = mFrameCount / 60.0;
+double now = mFrameCount / getFrameRate();
 
 	// update master timeline - not sure why this is done after update()
 	//mTimeline->stepTo( static_cast<float>( getElapsedSeconds() ) );

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -171,6 +171,7 @@ void AppBase::privateUpdate__()
 
 	mSignalUpdate.emit();
 
+//CI_LOG_I("update()");
 	update();	// call <ourApp>::update()
 
 	// update master timeline - not sure why this is done after update()

--- a/src/cinder/qtime/QuickTimeImplAvf.mm
+++ b/src/cinder/qtime/QuickTimeImplAvf.mm
@@ -367,20 +367,21 @@ void MovieBase::setLoop( bool loop, bool palindrome )
 	mPalindrome = (loop? palindrome: false);
 }
 
-bool MovieBase::stepForward()
+bool MovieBase::stepForward( int frms /* = 1 */ )
 {
 	if( ! mPlayerItem )
 		return false;
 	
 	bool can_step_forwards = [mPlayerItem canStepForward];
 	if( can_step_forwards ) {
-		[mPlayerItem stepByCount:1];
+		//[mPlayerItem stepByCount:1];
+		[mPlayerItem stepByCount:frms];
 	}
 	
 	return can_step_forwards;
 }
 
-bool MovieBase::stepBackward()
+bool MovieBase::stepBackward( int frms /* = 1 */ )
 {
 	if( ! mPlayerItem)
 		return false;
@@ -388,7 +389,8 @@ bool MovieBase::stepBackward()
 	bool can_step_backwards = [mPlayerItem canStepBackward];
 	
 	if (can_step_backwards) {
-		[mPlayerItem stepByCount:-1];
+		//[mPlayerItem stepByCount:-1];
+		[mPlayerItem stepByCount:-frms];
 	}
 	
 	return can_step_backwards;


### PR DESCRIPTION
Added frame capture - use 'c' key to toggle capture mode.
Modified Cinder library to allow for frame-based timing of top-level timeline and timer [getElapsedSeconds()]
Capture takes place at 30 fps by default, although this is settable
This branch corresponds to a branch also named TEX2-70-cb in CG-Lonestar/InteractiveFrontEnds which needs to be merged in as well.
Also added/reactivated frame rate display - toggle with 'f' key
